### PR TITLE
add react 17 to peer deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "lodash.isequal": "^4.5.0"
   },
   "peerDependencies": {
-    "react": "^16.8.0",
+    "react": "^16.8.5 || ^17.0.0",
     "react-dom": "^16.8.0"
   },
   "devDependencies": {


### PR DESCRIPTION
react-delta fails to install on projects with react 17. This should fix https://github.com/malerba118/react-delta/issues/8.